### PR TITLE
Move rust-crypto to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,6 @@ serde = "1.0.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 itoa = "0.4.3"
+
+[dev-dependencies]
 rust-crypto = "^0.2"


### PR DESCRIPTION
Thanks for cjson! This change helps with compiling to WASM targets.