### PR TITLE
Add readme to crates.io and build Wasm in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build
-        run: cargo build && cargo build --target wasm32-unknown-unknown && cargo build --target wasm32-wasi
+        run: rustup target add wasm32-unknown-unknown && rustup target add wasm32-wasi && cargo build && cargo build --target wasm32-unknown-unknown && cargo build --target wasm32-wasi
       - name: Run tests
         run: cargo test
       - name: Set up Go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build
-        run: cargo build --verbose
+        run: cargo build && cargo build --target wasm32-unknown-unknown && cargo build --target wasm32-wasi
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test
       - name: Set up Go
         uses: actions/setup-go@v2
       - name: Run integration tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
-name = "cjson"
-version = "0.1.1"
-authors = ["Radu M <root@radu.sh>"]
-edition = "2018"
+name        = "cjson"
+version     = "0.1.2"
+authors     = ["Radu M <root@radu.sh>"]
+edition     = "2018"
 description = "Canonical JSON serializer"
-license = "MIT"
+license     = "MIT"
+readme      = "readme.md"
 
 [dependencies]
-serde = "1.0.0"
+itoa         = "0.4.3"
+serde        = "1.0.0"
 serde_derive = "1.0"
-serde_json = "1.0"
-itoa = "0.4.3"
+serde_json   = "1.0"
 
 [dev-dependencies]
 rust-crypto = "^0.2"

--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,8 @@ This is an implementation for a canonical JSON serializer that tries to be
 compliant with [the OLPC minimal specification for canonical JSON][olpc].
 Additionally, the implementation also tries to be fully compatible with the [Go
 canonical JSON implementation][docker/go/canonical] used across the Docker and
-If you find any inconsistencies with the result of the serialization, please
-open an issue.
+Notary ecosystem. If you find any inconsistencies with the result of the
+serialization, please open an issue.
 
 Example - reading a JSON file and printing its canonical representation:
 

--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,6 @@ This is an implementation for a canonical JSON serializer that tries to be
 compliant with [the OLPC minimal specification for canonical JSON][olpc].
 Additionally, the implementation also tries to be fully compatible with the [Go
 canonical JSON implementation][docker/go/canonical] used across the Docker and
-Notary ecosystems.
-
 If you find any inconsistencies with the result of the serialization, please
 open an issue.
 
@@ -24,6 +22,9 @@ println!(
     cjson::to_string(&res).expect("cannot write canonical JSON")
 );
 ```
+
+> Note: this crate aims to always be compilable to the `wasm32-unknown-unknown`
+> and `wasm32-wasi` targets.
 
 ### Building and contributing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,24 @@
 //! canonical JSON implementation][docker/go/canonical] used across the Docker and
 //! Notary ecosystem.
 //! Example - reading a JSON file and printing its canonical representation:
-
+//!
 //! ```rust
+//! let data = r#"
+//! {
+//!     "name": "John Doe",
+//!     "age": 43,
+//!     "phones": [
+//!         "+44 1234567",
+//!         "+44 2345678"
+//!     ]
+//! }"#;
 //! let res: serde_json::Value =
-//!     serde_json::from_reader(input).expect("cannot deserialize input file");
-
-//! println!(
-//!     "{}",
-//!     cjson::to_string(&res).expect("cannot write canonical JSON")
-//! );
+//!     serde_json::from_str(data).expect("cannot deserialize input file");
+//!
+//! let canonical = cjson::to_string(&res).expect("cannot write canonical JSON");
+//! let expected = r#"{"age":43,"name":"John Doe","phones":["+44 1234567","+44 2345678"]}"#;
+//! assert_eq!(canonical, expected);
+//!
 //! ```
 #![deny(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,28 @@
-use serde_json;
-use serde_json::Value;
-use std::collections::BTreeMap;
-use std::io;
+//! A canonical JSON serializer that tries to be
+//! compliant with [the OLPC minimal specification for canonical JSON][olpc].
+//! Additionally, the implementation also tries to be fully compatible with the [Go
+//! canonical JSON implementation][docker/go/canonical] used across the Docker and
+//! Notary ecosystem.
+//! Example - reading a JSON file and printing its canonical representation:
+
+//! ```rust
+//! let res: serde_json::Value =
+//!     serde_json::from_reader(input).expect("cannot deserialize input file");
+
+//! println!(
+//!     "{}",
+//!     cjson::to_string(&res).expect("cannot write canonical JSON")
+//! );
+//! ```
+#![deny(missing_docs)]
+
+use serde_json::{self, Value};
+use std::{collections::BTreeMap, io};
 
 #[cfg(test)]
 mod tests;
 
+/// Serialize the given data structure as canonical JSON into the IO stream.
 pub fn to_writer<W, T: Sized>(mut writer: W, value: &T) -> Result<(), Error>
 where
     W: io::Write,
@@ -17,6 +34,7 @@ where
     Ok(())
 }
 
+/// Serialize the given data structure as a canonical JSON byte vector.
 pub fn to_vec<T: Sized>(value: &T) -> Result<Vec<u8>, Error>
 where
     T: serde::Serialize,
@@ -26,6 +44,7 @@ where
     Ok(writer)
 }
 
+/// Serialize the given data structure as a String of canonical JSON.
 pub fn to_string<T: Sized>(value: &T) -> Result<String, Error>
 where
     T: serde::Serialize,
@@ -142,9 +161,13 @@ fn from_value(val: &Value) -> Result<CanonicalValue, Error> {
     }
 }
 
+/// This enum represents all errors that can be returned when
+/// trying to serialize something as canonical JSON.
 #[derive(Debug)]
 pub enum Error {
+    /// Custom generic error.
     Custom(String),
+    /// IO error.
     Io(io::Error),
 }
 


### PR DESCRIPTION
This PR adds the readme from this repository to crates.io as well, and build Wasm targets in CI for each action run.

closes #6 