### PR TITLE
cargo: add repository URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition     = "2018"
 description = "Canonical JSON serializer"
 license     = "MIT"
 readme      = "readme.md"
+repository  = "https://github.com/engineerd/cjson"
 
 [dependencies]
 itoa         = "0.4.3"


### PR DESCRIPTION
This adds the github repository URL to cargo metadata, in order
to directly link to it from crates.io.